### PR TITLE
Fixed example error in multiply helper.

### DIFF
--- a/lib/math.js
+++ b/lib/math.js
@@ -159,7 +159,7 @@ helpers.modulo = function(a, b) {
  * @return {Number}
  * @alias multiply
  * @api public
- * @example {{ times 10 5 }} -> 50
+ * @example {{ multiply 10 5 }} -> 50
  */
 
 helpers.multiply = function(a, b) {


### PR DESCRIPTION
Fixed example error where times was used for the multiply example.