### PR TITLE
Update micromatch to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "html-tag": "^2.0.0",
     "is-glob": "^4.0.1",
     "kind-of": "^6.0.3",
-    "micromatch": "^3.1.5",
+    "micromatch": "^4.0.5",
     "relative": "^3.0.2",
     "striptags": "^3.1.1",
     "to-gfm-code-block": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,7 +1133,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -5443,6 +5443,14 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.5:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+micromatch@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
+
 middleware-rename-file@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/middleware-rename-file/-/middleware-rename-file-0.1.1.tgz#4788a5212d496bd5db9da93d53e7d61e8806763f"
@@ -6336,6 +6344,11 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pify@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
Updating micromatch from 3.x to 4.x. This reduces the bundle size from 757kb to 445kb.
No [breaking changes](https://github.com/micromatch/micromatch/blob/master/CHANGELOG.md) are affecting the project itself, but it might affect the customers. Because of this, we will need to bump the version as minor (given that we are still at 0.x version)

| Before | After |
|--------|--------|
| <img width="1416" alt="image" src="https://github.com/Budibase/handlebars-helpers/assets/15987277/2fbf72a8-5a60-4ff0-974d-033a25e0cd71"> | <img width="1416" alt="image" src="https://github.com/Budibase/handlebars-helpers/assets/15987277/b4149d39-4e63-4cd9-9b32-3de8ff044655"> | 