### PR TITLE
Revert "Remove UUID dependency"

### DIFF
--- a/lib/uuid.js
+++ b/lib/uuid.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const uuid = require('uuid');
 const helpers = module.exports;
 
 /**
@@ -9,6 +9,6 @@ const helpers = module.exports;
  * @example {{ uuid }} -> f34ebc66-93bd-4f7c-b79b-92b5569138bc
  */
 helpers.uuid = function() {
-  return crypto.randomUUID();
+  return uuid.v4();
 };
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "micromatch": "^4.0.5",
     "relative": "^3.0.2",
     "striptags": "^3.1.1",
-    "to-gfm-code-block": "^0.1.1"
+    "to-gfm-code-block": "^0.1.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "engine-handlebars": "^0.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8123,6 +8123,11 @@ uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
Reverting Budibase/handlebars-helpers#14

Using crypto works fine on the actual executions, but for some reason is not working fine on the frontend validation. 
![image](https://github.com/Budibase/handlebars-helpers/assets/15987277/06e13332-402d-40f3-b709-956f7e5721b2)

Reverting to use uuid, fixing any breaking change on its usage