### PR TITLE
Expose only collection helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ for (const key in lib) {
     var hbs = options.handlebars || options.hbs || require('handlebars');
     module.exports.handlebars = hbs;
     hbs.registerHelper(group);
-    return hbs.helpers;
+    return group;
   };
 }
 


### PR DESCRIPTION
When exposing helpers by collection, we are registering the collection helpers to the handlebars and returning all the handlebars:
```
for (const key in lib) {
  const group = lib[key];

  module.exports[key] = function(options) {
    options = options || {};
    var hbs = options.handlebars || options.hbs || require('handlebars');
    module.exports.handlebars = hbs;
    hbs.registerHelper(group);
    return hbs.helpers;
  };
}
```

When accessing different collections, we are getting the following issues:
1. Access `math`. This will register the `math` helpers and return all the helpers ✅
2. Then access `string`. The `string` helpers will be registered, and it will return all the helpers (both string and math) ❌

This will cause different import orders to export different things. The changes are adding consistency
