### PR TITLE
Add missing returns to examples

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -203,6 +203,7 @@ helpers.first = function(array, n) {
  * ```
  * @source <http://stackoverflow.com/questions/13861007>
  * @param {Array} `array`
+ * @param {Object} `options`
  * @return {String}
  * @block
  * @api public
@@ -352,7 +353,6 @@ helpers.join = function(array, separator) {
  *
  * @param {Array|String} `value`
  * @param {Number} `length`
- * @param {Object} `options`
  * @return {String}
  * @block
  * @api public
@@ -922,6 +922,7 @@ helpers.withSort = function(array, prop, options) {
  * @param {Array} `array`
  * @param {Object} `options`
  * @return {Array}
+ * @block
  * @api public
  * @example {{#each (unique ['a', 'a', 'c', 'b', 'e', 'e']) }}{{.}}{{/each}} -> acbe
  */

--- a/lib/array.js
+++ b/lib/array.js
@@ -85,7 +85,7 @@ helpers.before = function(array, n) {
  * @return {String}
  * @block
  * @api public
- * @example  {{#eachIndex [1, 2, 3]}} {{item}} is {{index}} {{/eachIndex}}
+ * @example  {{#eachIndex [1, 2, 3]}} {{item}} is {{index}} {{/eachIndex}} -> ' 1 is 0  2 is 1  3 is 2 '
  */
 
 helpers.eachIndex = function(array, options) {
@@ -115,7 +115,7 @@ helpers.eachIndex = function(array, options) {
  * @return {String}
  * @block
  * @api public
- * @example {{#filter [1, 2, 3] 2}}2 Found{{else}}2 not found{{/filter}}
+ * @example {{#filter [1, 2, 3] 2}}2 Found{{else}}2 not found{{/filter}} -> 2 Found
  */
 
 helpers.filter = function(array, value, options) {
@@ -206,7 +206,7 @@ helpers.first = function(array, n) {
  * @return {String}
  * @block
  * @api public
- * @example {{#forEach [{ 'name': 'John' }] }} {{ name }} {{/forEach}}
+ * @example {{#forEach [{ 'name': 'John' }] }} {{ name }} {{/forEach}} -> ' John '
  */
 
 helpers.forEach = function(array, options) {
@@ -670,7 +670,7 @@ helpers.sortBy = function(array, prop, options) {
  * @return {Array}
  * @block
  * @api public
- * @example {{ withAfter [1, 2, 3] 1 }} {{this}} {{/withAfter}}
+ * @example {{#withAfter [1, 2, 3] 1 }} {{this}} {{/withAfter}} -> ' 2  3 '
  */
 
 helpers.withAfter = function(array, idx, options) {
@@ -705,7 +705,7 @@ helpers.withAfter = function(array, idx, options) {
  * @return {Array}
  * @block
  * @api public
- * @example {{ withBefore [1, 2, 3] 2 }} {{this}} {{/withBefore}}
+ * @example {{#withBefore [1, 2, 3] 2 }} {{this}} {{/withBefore}} -> ' 1 '
  */
 
 helpers.withBefore = function(array, idx, options) {

--- a/lib/comparison.js
+++ b/lib/comparison.js
@@ -24,7 +24,7 @@ var helpers = module.exports;
  * @return {String}
  * @block
  * @api public
- * @example {{#and great magnificent}}both{{else}}no{{/and}}
+ * @example {{#and great magnificent}}both{{else}}no{{/and}} -> no
  */
 
 helpers.and = function() {
@@ -125,7 +125,7 @@ helpers.compare = function(a, operator, b, options) {
  * @param {Object} `options` Handlebars provided options object.
  * @block
  * @api public
- * @example {{#contains ['a', 'b', 'c'] 'd'}} This will not be rendered. {{else}} This will be rendered. {{/contains}}
+ * @example {{#contains ['a', 'b', 'c'] 'd'}} This will not be rendered. {{else}} This will be rendered. {{/contains}} -> ' This will be rendered. '
  */
 
 helpers.contains = function(collection, value, startIndex, options) {

--- a/lib/number.js
+++ b/lib/number.js
@@ -195,7 +195,7 @@ helpers.toInt = function(number) {
  * @param {Number} `precision` (Optional) An integer specifying the number of significant digits. If precison is not between 1 and 100 (inclusive), it will be coerced to `0`.
  * @return {String} A string representing a Number object in fixed-point or exponential notation rounded to precision significant digits.
  * @api public
- * @example {{toPrecision '1.1234' 2}}
+ * @example {{toPrecision '1.1234' 2}} -> 1.1
  */
 
 helpers.toPrecision = function(number, precision) {


### PR DESCRIPTION
Add missing returns to examples. This will be used for the documentation and the automated testing
